### PR TITLE
Fix the "Only variables should be passed by reference" error

### DIFF
--- a/src/Handler/MySQLiHandler.php
+++ b/src/Handler/MySQLiHandler.php
@@ -56,7 +56,8 @@ class MySQLiHandler extends AbstractHandler
      */
     public function write($record)
     {
-        $this->statement->bind_param('ssss', $record['channel'], $record['level'], $record['message'], $record['datetime']->format('U'));
+        $datetime = $record['datetime']->format('U');
+        $this->statement->bind_param('ssss', $record['channel'], $record['level'], $record['message'], $datetime);
         $this->statement->execute();
     }
 


### PR DESCRIPTION
Small fix that prevents the following error:
Whoops\Exception\ErrorException: Only variables should be passed by reference in file /.../vendor/bhavik/monolog-mysql/src/Handler/MySQLiHandler.php on line 59